### PR TITLE
Use Translate Locations on the page

### DIFF
--- a/git-cheatsheet/git-cheatsheet.js
+++ b/git-cheatsheet/git-cheatsheet.js
@@ -114,7 +114,7 @@ $(function () {
   // Build locations
   $.each(locationKeys(), function(i, loc) {
     $('#' + loc).attr('data-docs', translations[lang].locations.docs[loc]).
-        find('label').html(translations[lang].locations[loc])
+        find('h5').html(translations[lang].locations[loc])
   })
 
   // Build commands


### PR DESCRIPTION
I'm translating this to the _Simplified Chinese_.
But when I changed some docs to chinese,
I found the location names in the top bar and in docs is not same,
I think if we use same words on the top bar and in docs , the readers would got the meaning easier

And I found There is no label tag on the page, maybe you should use H5 tag here!

``` html
    <section id="stash" class="loc grid_2 alpha"><h5>stash</h5></section>
```
