### PR TITLE
added init <dir> to show how to create a new repo

### DIFF
--- a/git-cheatsheet/lang/en.json
+++ b/git-cheatsheet/lang/en.json
@@ -106,6 +106,10 @@
             "cmd": "branch --track <new branch name> <remote>/<branch>",
             "docs": "Create a new local branch from a remote-tracking branch."
         },
+        "init x": {
+            "cmd": "init <dir>",
+            "docs": "Create a new local Git repository in <dir>. The repository starts with no commits."
+        },
         "clone x": {
             "cmd": "clone <repo>",
             "docs": "Download the repository specified by <repo> and checkout `HEAD` of the main branch."

--- a/src/commands.mjs
+++ b/src/commands.mjs
@@ -196,6 +196,13 @@ export const commands = [
   },
   {
     "left":      "workspace",
+    "right":     "local_repo",
+    "direction": "dn",
+    "key":       "init x",
+    "tags":      "Creating Projects",
+  },
+  {
+    "left":      "workspace",
     "right":     "remote_repo",
     "direction": "dn",
     "key":       "clone x",


### PR DESCRIPTION
Added `init <dir>` to the schematic.

I often find it useful for new git users to play around with local git repo's, and `git init` is vital in that case.