### PR TITLE
Clarify that push does not push all branches by default

### DIFF
--- a/git-cheatsheet/lang/en.json
+++ b/git-cheatsheet/lang/en.json
@@ -124,7 +124,7 @@
         },
         "push": {
             "cmd": "push",
-            "docs": "Update the server with your commits across all branches that are *COMMON* between your local copy and the server. Local branches that were never pushed to the server in the first place are not shared."
+            "docs": "Update the server with your commits to the current branch. `--all` transfers the commits of all branches."
         },
         "push x x": {
             "cmd": "push <remote> <branch>",


### PR DESCRIPTION
Hey there!
I saw that the english description of the `push` command seems to be incorrect.
I updated the relevant description, its derived from the german translation, which seems to be correct.